### PR TITLE
Added .sublime-project to .gitignore and added swarm to readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@
 
 # Project files should be checked into the repository, unless a significant
 # proportion of contributors will probably not be using Sublime Text
-# *.sublime-project
+*.sublime-project
 
 
 # -- Emacs ---------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Region V 2018-2019
+&nbsp;&nbsp;&nbsp;:honeybee:&nbsp;&nbsp;&nbsp;&nbsp;:honeybee:
+
+:honeybee:&nbsp;&nbsp;&nbsp;&nbsp;:honeybee::honeybee:
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;:honeybee:
 
 See the [wiki](https://github.com/ut-ras/r5-2019/wiki)!
 


### PR DESCRIPTION
## Description
Added 100% more swarm to ```README.md```.

Also it turns out the ```.gitignore``` template used has ```*.sublime-project``` commented out in case most contributors use sublime (which is definitely not true).

